### PR TITLE
Update A2A-as-RiC.ttl

### DIFF
--- a/examples/A2A-as-RiC.ttl
+++ b/examples/A2A-as-RiC.ttl
@@ -1,4 +1,4 @@
-@prefix : <https://memorix.io/NL-SAA/564021ce-aabb-0011-2233-f778c6c06689#> .
+@prefix : <https://hetutrechtsarchief.nl/collectie/F6C0F0E40850E53EE0434701000A1872#> .
 @prefix rico: <https://www.ica.org/standards/RiC/ontology#> .
 @prefix pnv: <https://w3id.org/pnv#> .
 @prefix edm: <http://www.europeana.eu/schemas/edm/> .
@@ -9,8 +9,9 @@
 # Note: for readability the identifiers for persons are in the prefix of the document and contain describing labels. 
 # It is probably better to use full URL's to link to individual persons (if the RMS supports this of course).
 
-<https://memorix.io/NL-SAA/564021ce-aabb-0011-2233-f778c6c06689#> a rico:Record ;
-  rico:ContentType <http://vocab.getty.edu/aat/300027418> ;
+<https://hetutrechtsarchief.nl/collectie/F6C0F0E40850E53EE0434701000A1872> 
+  a rico:Record ;
+  rico:hasContentOfType <http://vocab.getty.edu/aat/300027418> ;
   rico:heldBy <https://hetutrechtsarchief.nl> ;
   edm:isShownAt 
     <http://www.hetutrechtsarchief.nl/collectie/archiefbank/archieftoegangen/zoekresultaat?mivast=39&amp;miadt=39&amp;miaet=54&amp;micode=463-737-01&amp;minr=29574995&amp;miview=ldt> ,
@@ -20,31 +21,32 @@
   rico:hasInstantiation [
     a rico:Instantiation ;
     rico:identifier "997" ;
-    rico:title "BS Huwelijk"@nl 
+    rico:title "Huwelijksakte van J.F. van der Sloot en M.E. Verheijde, Utrecht 1937"@nl 
   ] ;
   rico:isComponentOf [
     a rico:Instantiation ;
     rico:identifier "463" ;
-    rico:instantiates [
-      a rico:Record ;
-      edm:isShownAt <https://hetutrechtsarchief.nl/onderzoek/resultaten/archieven?mivast=39&mizig=210&miadt=39&micode=463&milang=nl&mizk_alle=463&miview=inv2> ;
-      rdfs:label "Burgerlijke Stand van de gemeenten in de provincie Utrecht 1903-1942" 
-    ] 
+    rico:instantiates <https://hetutrechtsarchief.nl/collectie/609C5B9E4B3D4642E0534701000A17FD> ;
   ] .
   
+<https://hetutrechtsarchief.nl/collectie/609C5B9E4B3D4642E0534701000A17FD>
+    a rico:RecordSet ;
+    rdfs:label "Burgerlijke Stand van de gemeenten in de provincie Utrecht 1903-1942" .
+
 :huwelijk a rico:Event ;
    rico:involves :bruid, :bruidegom, :vader-van-de-bruidegom, :moeder-van-de-bruidegom, :vader-van-de-bruid, :moeder-van-de-bruid  ;
    rico:hasEventType <http://vocab.getty.edu/aat/300055475> ;
-   rico:Date [
+   rico:isAssociatedWithDate [
+     a rico:Date ;
      rico:normalizedDateValue "1937-09-01"^^xsd:date
    ] ;
    rico:hasLocation [
      a rico:Place ;
-     rico:hasPlaceName <https://www.geonames.org/2745912/utrecht.html>
+     rico:hasPlaceName <https://sws.geonames.org/2745912/>
    ] ;
-   rico:resultsIn <https://memorix.io/NL-UtHUA/564021ce-aabb-0011-2233-f778c6c06689#> .
+   rico:resultsIn <https://hetutrechtsarchief.nl/collectie/F6C0F0E40850E53EE0434701000A1872> .
 
-:bruid a rico:Person ;
+:bruidegom a rico:Person ;
   rico:hasAgentName [
     a rico:AgentName ;
     rico:textualValue "Joannes Franciscus van der Sloot" ;
@@ -53,10 +55,10 @@
     pnv:givenName "Joannes Franciscus" 
   ] ;
   schema:gender schema:Male ;
-  rico:hasOccupationOfType <https://nl.wikipedia.org/wiki/Proefmeester> ; 
+  rico:hasOccupationOfType <http://www.wikidata.org/entity/Q7316604> ; 
   rico:involvedIn :huwelijk .
     
-:bruidegom a rico:Person ;
+:bruid a rico:Person ;
   rico:hasAgentName [
     a rico:AgentName ;
     rico:textualValue "Maria Elisabeth Verheijde" ;
@@ -66,44 +68,41 @@
   schema:gender schema:Female ;
   rico:involvedIn :huwelijk .
 
-:vader-van-de-bruid a rico:Person ;
+:vader-van-de-bruidegom a rico:Person ;
   rico:hasAgentName [
     a rico:AgentName ;
     rico:textualValue "Johannes Gerardus van der Sloot" 
   ] ;
   schema:gender schema:Male ;
-  rico:hasFamilyLinkWith :bruidegom ;
-  rico:hasFamilyType <https://schema.org/parent> ;
-  rico:involvedIn :huwelijk .
-
-:moeder-van-de-bruid a rico:Person ;
-  rico:hasAgentName [
-    a rico:AgentName ;
-    rico:textualValue "Johanna Maria Binken" 
-  ] ;
-  schema:gender schema:Female ;
-  rico:hasFamilyLinkWith :bruidegom ;
-  rico:hasFamilyType <https://schema.org/parent> ;
-  rico:involvedIn :huwelijk .
-
-:vader-van-de-bruidegom a rico:Person ;
-  rico:hasAgentName [
-    a rico:AgentName ;
-    rico:textualValue "Joannes Antonius Arnoldus Verheijde" 
-  ] ;
-  schema:gender schema:Male ;
-  rico:hasFamilyLinkWith :bruid ;
-  rico:hasFamilyType <https://schema.org/parent> ;
+  rico:hasChild :bruidegom ;
+  # hoe? - overleden, - leeftijd
   rico:involvedIn :huwelijk .
 
 :moeder-van-de-bruidegom a rico:Person ;
   rico:hasAgentName [
     a rico:AgentName ;
+    rico:textualValue "Johanna Maria Binken" 
+  ] ;
+  schema:gender schema:Female ;
+  rico:hasChild :bruidegom ;
+  rico:involvedIn :huwelijk .
+
+:vader-van-de-bruid a rico:Person ;
+  rico:hasAgentName [
+    a rico:AgentName ;
+    rico:textualValue "Joannes Antonius Arnoldus Verheijde" 
+  ] ;
+  schema:gender schema:Male ;
+  rico:hasChild :bruid ;
+  rico:involvedIn :huwelijk .
+
+:moeder-van-de-bruid a rico:Person ;
+  rico:hasAgentName [
+    a rico:AgentName ;
     rico:textualValue "Anna Maria Lambricks" 
   ] ;
   schema:gender schema:Female ;
-  rico:hasFamilyLinkWith :bruid ;
-  rico:hasFamilyType <https://schema.org/parent> ;
+  rico:hasChild :bruid ;
   rico:involvedIn :huwelijk .
 
 <http://vocab.getty.edu/aat/300055475> a rico:EventType ;
@@ -119,8 +118,8 @@
     rico:textualValue "Het Utrechts Archief"@nl
   ] .
   
-<https://nl.wikipedia.org/wiki/Proefmeester> a rico:OccupationType ;
-  rdfs:label "Proefmeester"@nl .
+<http://www.wikidata.org/entity/Q7316604> a rico:OccupationType ;
+  rdfs:label "winkelbediende"@nl .
   
-<https://www.geonames.org/2745912/utrecht.html> a rico:PlaceName ;
+<https://sws.geonames.org/2745912/> a rico:PlaceName ;
   rico:textualValue "Utrecht"@nl .


### PR DESCRIPTION
* ik heb de echte uri van het HUA gehaald en niet die van memorix
* vuistregel is: classes zijn met een hoofdletter, properties met een kleine. Dus je kunt geen relatie leggen met rico:ContentType
* akte nr 997 heeft als titel: "Huwelijksakte blabla ..."
* ook van de archiefinventaris 463 kan ik de uri van HUA gebruiken
* rico:Date kan dus ook niet een relatie modelleren
* geonames heeft een nogal ingewikkelde manier om uris te maken. dit is de juiste (let op: httpS, SWS en afsluitende "/")
* er is een hasChild relatie gedefinieerd